### PR TITLE
Fix slicing of std::exception

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -316,7 +316,7 @@ int main(int argc, char *argv[])
         optix_context->destroy();
                                             
     }                                               
-    catch (std::exception e)                        
+    catch (const std::exception &e)                        
     {                                               
         std::cerr<<"[OptiX]: "<<e.what()<<std::endl;
         cleanup();                                  


### PR DESCRIPTION
When exception happens, application prints very generic output like `[OptiX]: std::exception`. This is due to fact that std::exception is cached by value, not reference.

Catch exceptions by const reference to produce more informative console output. After the fix, application prints `[OptiX]: Failed to load OptiX library` instead.