### PR TITLE
Update OptiX to 7.6

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -5,7 +5,7 @@ DEBUG = ARGUMENTS.get("debug", 0)
 
 CUDA_PATH = os.environ['CUDA_PATH']
 CUDA_INCLUDE_PATH = CUDA_PATH + "/include"
-OPTIX_PATH = "C:/ProgramData/NVIDIA Corporation/OptiX SDK 7.4.0"
+OPTIX_PATH = "C:/ProgramData/NVIDIA Corporation/OptiX SDK 7.6.0"
 OPTIX_INCLUDE_PATH = OPTIX_PATH + "/include"
 
 ENV = Environment(CPPPATH = ['.', OPTIX_INCLUDE_PATH, "./contrib/OpenImageIO/include", CUDA_INCLUDE_PATH

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -691,7 +691,11 @@ int main(int argc, char *argv[])
     // Set the denoiser parameters
     OptixDenoiserParams denoiser_params = {};
     // TODO: Expose option for this
+#if OPTIX_VERSION >= 70600
     denoiser_params.denoiseAlpha = OptixDenoiserAlphaMode(0);
+#else
+    denoiser_params.denoiseAlpha = 0;
+#endif
     denoiser_params.blendFactor = blend;
     CU_CHECK(cudaMalloc((void**)&denoiser_params.hdrIntensity, sizeof(float)));
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -691,7 +691,7 @@ int main(int argc, char *argv[])
     // Set the denoiser parameters
     OptixDenoiserParams denoiser_params = {};
     // TODO: Expose option for this
-    denoiser_params.denoiseAlpha = 0;
+    denoiser_params.denoiseAlpha = OptixDenoiserAlphaMode(0);
     denoiser_params.blendFactor = blend;
     CU_CHECK(cudaMalloc((void**)&denoiser_params.hdrIntensity, sizeof(float)));
 


### PR DESCRIPTION
I've used OptixDenoiserAlphaMode instead of plain int value because otherwise, it throws an error during the compilation. Not sure if this is the right thing to do, but everything works fine for me after I made this change, so I decided to create a pull request so you can check this out and decide if this is worth merging.
